### PR TITLE
Fixed swapped cache methods

### DIFF
--- a/UserSync/Utils/MSALUserTokenMemoryCache.cs
+++ b/UserSync/Utils/MSALUserTokenMemoryCache.cs
@@ -80,16 +80,16 @@ namespace UserSync.Utils
 
         private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
         {
-            this.LoadUserTokenCacheFromMemory();
-        }
+			// if the access operation resulted in a cache update
+			if (args.HasStateChanged)
+			{
+				this.PersistUserTokenCache();
+			}
+		}
 
         private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            // if the access operation resulted in a cache update
-            if (args.HasStateChanged)
-            {
-                this.PersistUserTokenCache();
-            }
+			this.LoadUserTokenCacheFromMemory();
         }
 
         public string GetSignedInUsersCacheKey()


### PR DESCRIPTION
As an urgent hotfix, I have fixed UserTokenCacheAfterAccessNotification and UserTokenCacheBeforeAccessNotification swapped implementations.

Jean-Marc suggested to improve our .NET 4.X cache providers according to the latest changes on microsoft-authentication-extensions-for-dotnet but since this will require more time, I would like to do this quick hotfix first to prevent developers of cloning a wrong class as soon as possible.