### PR TITLE
Adding VS Code Extension Recommendation on VS Code.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["ms-azuretools.ms-entra"]
+}


### PR DESCRIPTION
Adding configs prompting a user/developer to install the ms-entra external ID extension when using VS Code editor.